### PR TITLE
add confirmed local / else where

### DIFF
--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -1,35 +1,68 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
-    <time-bar-chart
+    <time-stacked-bar-chart
       :title="$t('陽性患者数')"
       :title-id="'number-of-confirmed-cases'"
       :chart-id="'time-bar-chart-patients'"
       :chart-data="patientsGraph"
       :date="Data.patients.date"
+      :items="patientsItems"
+      :labels="patientsLabels"
       :unit="$t('人')"
-      :url="
-        'https://zh.wikipedia.org/wiki/2019%E5%86%A0%E7%8B%80%E7%97%85%E6%AF%92%E7%97%85%E8%87%BA%E7%81%A3%E7%96%AB%E6%83%85'
-      "
+      :data-labels="patientsDataLabels"
     />
+    <!-- 件.tested = 検査数 -->
   </v-col>
 </template>
 
 <script>
 import Data from '@/data/data.json'
-import formatGraph from '@/utils/formatGraph'
-import TimeBarChart from '@/components/TimeBarChart.vue'
+import TimeStackedBarChart from '@/components/TimeStackedBarChart.vue'
 
 export default {
   components: {
-    TimeBarChart
+    TimeStackedBarChart
   },
   data() {
-    // 感染者数グラフ
-    const patientsGraph = formatGraph(Data.patients_summary.data)
+    const patientsData = {
+      境外: {},
+      本土: {}
+    }
+    const patientsLabels = []
 
+    Data.patients.data.map(x => {
+      const dateString = x['リリース日'].substr(-5, 5).replace('-', '/')
+
+      patientsData.境外 = {
+        [dateString]: 0,
+        ...patientsData.境外
+      }
+      patientsData.本土 = {
+        [dateString]: 0,
+        ...patientsData.本土
+      }
+
+      patientsData[x.境外或本土] = {
+        ...patientsData[x.境外或本土],
+        [dateString]: patientsData[x.境外或本土][dateString] + 1
+      }
+
+      if (!patientsLabels.includes(dateString)) {
+        patientsLabels.push(dateString)
+      }
+    })
+    const patientsItems = [this.$t('境外'), this.$t('本土')]
+    const patientsDataLabels = [this.$t('境外'), this.$t('本土')]
+    patientsLabels.reverse()
     const data = {
       Data,
-      patientsGraph
+      patientsGraph: [
+        Object.values(patientsData.境外).reverse(),
+        Object.values(patientsData.本土).reverse()
+      ],
+      patientsItems,
+      patientsLabels,
+      patientsDataLabels
     }
     return data
   }


### PR DESCRIPTION
<!-- 請盡量附上 Issue 編號 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決的 Issue / Resolved Issues
https://github.com/PichuChen/covid19/issues/2

## 📝 關聯的 Issue / Related Issues
- #0
- #0

## ⛏ 變更内容 / Details of Changes
<!-- 請簡要的寫下變更內容 -->
<!-- List down your changes concisely -->
components/cards/ConfirmedCasesNumberCard.vue
changed this to time-stacked-bar-chart

## 📸 螢幕截圖 / Screenshots
<!-- 有截圖的畫面修改會比較好審查 -->
<!-- Changes in styles would be easier to review with screenshots! -->


![Screen Shot 2020-03-24 at 10 11 44 PM](https://user-images.githubusercontent.com/2888757/77435812-b485dc80-6e1d-11ea-9ca7-a46d7f596767.png)

Original the graph using Data.patients_summary. but this need to be stacked graph 
which follow the Data.inspections_summary
current I use js to modify  data.patients  as time-stacked-bar-chart format

better way is the Data.patients_summary

```
patients_summary: {
date: {},
"data": { 
"境外": [], //item is daily count 
"本土":[]
},
labels:[] // "1/15.. date label"
}
```